### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/app/lib/wikihelper/wikihelper.go
+++ b/app/lib/wikihelper/wikihelper.go
@@ -1,7 +1,7 @@
 package wikihelper
 
 import (
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 	"net/url"
 	"regexp"
 	"strings"


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
